### PR TITLE
new: SECURITY disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+The **Falco** team and community take security bugs in all Falco projects seriously.
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Supported Versions
+
+Security updates will typically only be applied to the latest release (at least until **Falco** reaches first stable major version).
+
+| Version.   | Supported          |
+| ---------- | ------------------ |
+| >=0.15.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+To report a security issue, email opensource@sysdig.com and include the word "SECURITY" in the subject line.
+
+The **Falco** team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Note also that the team can use [GitHub Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories) to disclose, fix, and publish information about the vulnerability you responsibly reported to us.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,11 @@ Security updates will typically only be applied to the latest release (at least 
 
 | Version.   | Supported          |
 | ---------- | ------------------ |
-| >=0.15.x   | :white_check_mark: |
+| >=0.18.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-To report a security issue, email opensource@sysdig.com and include the word "SECURITY" in the subject line.
+To report a security issue, email [opensource@sysdig.com](mailto:opensource@sysdig.com?subject=SECURITY) and include the word "SECURITY" in the subject line.
 
 The **Falco** team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 


### PR DESCRIPTION
Introducing a security policy for disclosure and management of reported vulnerabilities.

This file, when merged, will act as security policy for all the **falcosecurity** organization projects.