### PR TITLE
feat(docs): Updating security reporting email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Security updates will typically only be applied to the latest release (at least 
 
 ## Reporting a Vulnerability
 
-To report a security issue, email [opensource@sysdig.com](mailto:opensource@sysdig.com?subject=SECURITY) and include the word "SECURITY" in the subject line.
+To report a security issue, email [cncf-falco-maintainers@lists.cncf.io](mailto:cncf-falco-maintainers@lists.cncf.io?subject=SECURITY) and include the word "SECURITY" in the subject line.
 
 The **Falco** team will send a response indicating the next steps in handling your report. After the initial reply to your report, the team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 


### PR DESCRIPTION
We had a user report a potential security concern and we noticed this email address.
Having a security report tied to a single vendor doesn't seem to embrace vendor neutrality.

Now all Falco maintainers will receive these reports.

Signed-off-by: Kris Nova <kris@nivenly.com>