### PR TITLE
update(.github): template for support menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Support
-    url: https://slack.k8s.io
-    about: Please ask and answer questions here.
+    url: https://kubernetes.slack.com/?redir=%2Fmessages%2Ffalco
+    about: Please ask and answer questions in the #falco channel (Kubernetes Slack)


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

This PR updates the URL for support requests, which now points to the #falco channel in the Kubernetes slack.