### PR TITLE
update(OWNERS): move inactive maintainers to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,7 @@
 approvers:
+  - leogr
+emeritus_approvers:
   - leodido
   - fntlnz
   - kris-nova
   - mfdii
-  - leogr
-reviewers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - mfdii
-  - leogr

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - leogr
+  - maxgio92
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157 (see: https://github.com/falcosecurity/evolution/issues/157), this PR proposes to move to `emeritus_approvers` maintainers that have been inactive in the past 6 months, as for our governance (see: https://github.com/falcosecurity/.github/blob/master/GOVERNANCE.md#project-inactivity). Maintainers are invited to have a discussion and take a decision.

cc @falcosecurity/maintainers 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

@leodido has non-zero devstats in the past 6 months, however from https://github.com/falcosecurity/falco/issues/2106#issuecomment-1182608352 I understand he intends to step down. If not, please have a discussion below.
